### PR TITLE
Let lzma-enumerator build under ghc-7.6

### DIFF
--- a/lzma-enumerator.cabal
+++ b/lzma-enumerator.cabal
@@ -1,5 +1,5 @@
 name:                lzma-enumerator
-version:             0.1.3
+version:             0.1.4
 synopsis:            Enumerator interface for lzma/xz compression.
 description:
   High level bindings to xz-utils.
@@ -29,7 +29,7 @@ library
   build-depends:
     base         >= 3      && < 5,
     bindings-DSL >= 1.0    && < 1.1,
-    bytestring   >= 0.9.1  && < 0.10,
+    bytestring   >= 0.9.1  && < 0.11,
     enumerator   >= 0.4.10 && < 0.5,
     mtl          >= 2      && < 3
   ghc-options:

--- a/src/Bindings/Lzma.hsc
+++ b/src/Bindings/Lzma.hsc
@@ -6,6 +6,8 @@ included in the liblinear archive, available for download at
 
 #include <bindings.dsl.h>
 #include <lzma.h>
+#include <stdio.h>
+#include <string.h>
 
 module Bindings.Lzma where
 #strict_import


### PR DESCRIPTION
Upped the bytestring version, and also added some C header files that broke compilation on my Linux system.
